### PR TITLE
fix: correct WPC load capacity handling

### DIFF
--- a/active_adaptation/envs/mdp/randomizations/core.py
+++ b/active_adaptation/envs/mdp/randomizations/core.py
@@ -825,8 +825,8 @@ class window_cap_hand_load(Randomization):
             if single_side_local_ids.numel() > 0:
                 left_side = torch.rand(single_side_local_ids.shape, device=self.device) < 0.5
                 weights[single_side_local_ids] = 0.0
-                weights[single_side_local_ids, 0] = left_side.float() * 0.5
-                weights[single_side_local_ids, 1] = (~left_side).float() * 0.5
+                weights[single_side_local_ids, 0] = left_side.float()
+                weights[single_side_local_ids, 1] = (~left_side).float()
 
         self.body_load_weights[env_ids] = weights
 

--- a/active_adaptation/utils/window_load_capacity.py
+++ b/active_adaptation/utils/window_load_capacity.py
@@ -264,6 +264,37 @@ class WindowLoadCapacityLookup:
                 f"Capacity labels from {resolved_path} matched {labeled_motion_ids.size}/{num_motions} motions; "
                 f"missing first ids={preview}. Use missing_motion_policy='zero' only if this is intentional."
             )
+        motion_lengths_np = _to_numpy_int64(motion_lengths)
+        # Labels generated before the half-open interval fix used length - 1
+        # for the final end. Normalize them in memory without rewriting artifacts.
+        for motion_id in labeled_motion_ids:
+            idx = np.flatnonzero(mapped.motion_ids == motion_id)
+            final_idx = idx[np.argmax(mapped.end_frames[idx])]
+            if int(mapped.end_frames[final_idx]) == int(motion_lengths_np[motion_id]) - 1:
+                mapped.end_frames[final_idx] = int(motion_lengths_np[motion_id])
+        if missing_policy == "error":
+            coverage_errors = []
+            for motion_id in range(num_motions):
+                idx = np.flatnonzero(mapped.motion_ids == motion_id)
+                order_local = np.argsort(mapped.start_frames[idx], kind="stable")
+                starts_local = mapped.start_frames[idx][order_local]
+                ends_local = mapped.end_frames[idx][order_local]
+                expected_end = max(int(motion_lengths_np[motion_id]), 1)
+                contiguous = (
+                    starts_local.size > 0
+                    and int(starts_local[0]) == 0
+                    and int(ends_local[-1]) == expected_end
+                    and np.array_equal(ends_local[:-1], starts_local[1:])
+                )
+                if not contiguous:
+                    coverage_errors.append(
+                        (motion_id, starts_local[:4].tolist(), ends_local[-4:].tolist(), expected_end)
+                    )
+            if coverage_errors:
+                raise ValueError(
+                    f"Capacity labels from {resolved_path} do not continuously cover "
+                    f"{len(coverage_errors)}/{num_motions} motions; first errors={coverage_errors[:5]}"
+                )
 
         order = np.lexsort((mapped.end_frames, mapped.start_frames, mapped.motion_ids))
         motion_ids = mapped.motion_ids[order].astype(np.int64, copy=False)

--- a/tests/test_window_load_capacity.py
+++ b/tests/test_window_load_capacity.py
@@ -1,0 +1,70 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from active_adaptation.envs.mdp.randomizations.core import window_cap_hand_load
+from active_adaptation.utils.window_load_capacity import WindowLoadCapacityLookup
+
+
+class WindowLoadCapacityTest(unittest.TestCase):
+    def write_labels(self, path: Path, starts, ends):
+        np.savez(
+            path,
+            motion_files=np.asarray(["/data/a.npz"]),
+            bin_motion_idx=np.zeros(len(starts), dtype=np.int32),
+            bin_idx=np.arange(len(starts), dtype=np.int32),
+            start_frame=np.asarray(starts, dtype=np.int32),
+            end_frame=np.asarray(ends, dtype=np.int32),
+            window_cap_kg=np.ones(len(starts), dtype=np.float32),
+        )
+
+    def load(self, path: Path):
+        return WindowLoadCapacityLookup.from_label_file(
+            path,
+            motion_source_paths=["/data/a.npz"],
+            motion_labels=[{"source_path": "/data/a.npz"}],
+            motion_lengths=[10],
+            motion_fps=50.0,
+            device="cpu",
+            missing_motion_policy="error",
+        )
+
+    def test_legacy_final_endpoint_is_normalized(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "labels.npz"
+            self.write_labels(path, [0, 5], [5, 9])
+
+            result = self.load(path).lookup(torch.tensor([0]), torch.tensor([9]))
+
+            self.assertTrue(result["valid"].item())
+
+    def test_gap_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "labels.npz"
+            self.write_labels(path, [0, 6], [5, 10])
+
+            with self.assertRaisesRegex(ValueError, "continuously cover"):
+                self.load(path)
+
+    def test_single_side_load_preserves_total_weight(self):
+        load = object.__new__(window_cap_hand_load)
+        load.env = SimpleNamespace(device=torch.device("cpu"))
+        load.split_ratio_low = 0.35
+        load.split_ratio_high = 0.65
+        load.single_side_load_ratio = 1.0
+        load.body_load_weights = torch.zeros((32, 2))
+        env_ids = torch.arange(32)
+
+        torch.manual_seed(0)
+        load._sample_body_load_weights(env_ids)
+
+        torch.testing.assert_close(load.body_load_weights.sum(dim=1), torch.ones(32))
+        self.assertTrue(((load.body_load_weights == 0.0) | (load.body_load_weights == 1.0)).all())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize legacy inclusive final endpoints to half-open WPC intervals
- reject label files with gaps or overlaps in motion coverage
- preserve the requested total load when sampling a single loaded hand
- add focused regression tests for all three cases

## Testing
- `.venv/bin/python -m unittest tests/test_window_load_capacity.py` (3 tests passed)

No datasets, checkpoints, generated outputs, or logs are included.